### PR TITLE
Added missing dependency on zlib to setup-mingw.sh

### DIFF
--- a/setup-mingw.sh
+++ b/setup-mingw.sh
@@ -13,6 +13,7 @@ PACKAGES="msys-wget
           msys-make
           gcc
           g++
+          mingw32-libz-dev
          "
 
 mingw-get install $PACKAGES


### PR DESCRIPTION
After clean install of mingw and run of "setup-mingw.sh", the build failed with "The program can't start because zlib1.dll is missing" error. I tracked it down to the one missing package "mingw32-libz-dev". The required change is in this pull request.
